### PR TITLE
Allow storing OpenAI Chat information in MongoDB

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -23,6 +23,7 @@ jobs:
         env:
           APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          CHAT_ASSISTANTS: ${{ secrets.CHAT_ASSISTANTS }}
         working-directory: scripts/commands
         run: |
           python3 commands.py

--- a/.github/workflows/discord_canary.yml
+++ b/.github/workflows/discord_canary.yml
@@ -23,6 +23,7 @@ jobs:
         env:
           APPLICATION_ID: ${{ secrets.CANARY_APPLICATION_ID }}
           BOT_TOKEN: ${{ secrets.CANARY_BOT_TOKEN }}
+          CHAT_ASSISTANTS: ${{ secrets.CHAT_ASSISTANTS }}
         working-directory: scripts/commands
         run: |
           python3 commands.py

--- a/.github/workflows/sam.yml
+++ b/.github/workflows/sam.yml
@@ -41,7 +41,6 @@ jobs:
           MONGODB_URL: ${{ secrets.MONGODB_URL }}
           MONGODB_DATABASE: ${{ secrets.MONGODB_DATABASE }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_CHAT_SYSTEM_MESSAGE: ${{ secrets.OPENAI_CHAT_SYSTEM_MESSAGE }}
-          OPENAI_CHAT_ASSISTANT_MESSAGE: ${{ secrets.OPENAI_CHAT_ASSISTANT_MESSAGE }}
+          CHAT_DEFAULT_ASSISTANT: ${{ secrets.CHAT_DEFAULT_ASSISTANT }}
         run: |
-          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --resolve-s3 --parameter-overrides "ApplicationIDParameter=$APPLICATION_ID BotTokenParameter=$BOT_TOKEN PublicKeyParameter=$PUBLIC_KEY MongoDbUrl=$MONGODB_URL MongoDbDatabase=$MONGODB_DATABASE OpenAiApiKey=$OPENAI_API_KEY OpenAiChatSystemMessage=$OPENAI_CHAT_SYSTEM_MESSAGE OpenAiChatAssistantMessage=$OPENAI_CHAT_ASSISTANT_MESSAGE"
+          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --resolve-s3 --parameter-overrides "ApplicationIDParameter=$APPLICATION_ID BotTokenParameter=$BOT_TOKEN PublicKeyParameter=$PUBLIC_KEY MongoDbUrl=$MONGODB_URL MongoDbDatabase=$MONGODB_DATABASE OpenAiApiKey=$OPENAI_API_KEY ChatDefaultAssistant=$CHAT_DEFAULT_ASSISTANT"

--- a/.github/workflows/sam_canary.yml
+++ b/.github/workflows/sam_canary.yml
@@ -40,7 +40,6 @@ jobs:
           PUBLIC_KEY: ${{ secrets.CANARY_PUBLIC_KEY }}
           MONGODB_URL: ${{ secrets.CANARY_MONGODB_URL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_CHAT_SYSTEM_MESSAGE: ${{ secrets.OPENAI_CHAT_SYSTEM_MESSAGE }}
-          OPENAI_CHAT_ASSISTANT_MESSAGE: ${{ secrets.OPENAI_CHAT_ASSISTANT_MESSAGE }}
+          CHAT_DEFAULT_ASSISTANT: ${{ secrets.CHAT_DEFAULT_ASSISTANT }}
         run: |
-          sam deploy --config-file canary.toml --no-confirm-changeset --no-fail-on-empty-changeset --resolve-s3 --parameter-overrides "ApplicationIDParameter=$APPLICATION_ID BotTokenParameter=$BOT_TOKEN PublicKeyParameter=$PUBLIC_KEY MongoDbUrl=$MONGODB_URL OpenAiApiKey=$OPENAI_API_KEY OpenAiChatSystemMessage=$OPENAI_CHAT_SYSTEM_MESSAGE OpenAiChatAssistantMessage=$OPENAI_CHAT_ASSISTANT_MESSAGE"
+          sam deploy --config-file canary.toml --no-confirm-changeset --no-fail-on-empty-changeset --resolve-s3 --parameter-overrides "ApplicationIDParameter=$APPLICATION_ID BotTokenParameter=$BOT_TOKEN PublicKeyParameter=$PUBLIC_KEY MongoDbUrl=$MONGODB_URL OpenAiApiKey=$OPENAI_API_KEY ChatDefaultAssistant=$CHAT_DEFAULT_ASSISTANT"

--- a/sam/interact/src/main/kotlin/Handler.kt
+++ b/sam/interact/src/main/kotlin/Handler.kt
@@ -7,7 +7,7 @@ import cloud.drakon.ktdiscord.interaction.applicationcommand.ApplicationCommandD
 import cloud.drakon.tempestbot.interact.commands.citations.citationHandler
 import cloud.drakon.tempestbot.interact.commands.ffxiv.lodestone.lodestoneHandler
 import cloud.drakon.tempestbot.interact.commands.ffxiv.universalis
-import cloud.drakon.tempestbot.interact.commands.openai.createCompletion
+import cloud.drakon.tempestbot.interact.commands.openai.chat
 import cloud.drakon.tempestbot.interact.commands.openai.createImage
 import cloud.drakon.tempestbot.interact.commands.rory
 import cloud.drakon.tempestbot.interact.commands.translate
@@ -57,7 +57,7 @@ class Handler: RequestStreamHandler {
                         applicationCommand
                     )
 
-                    "chat" -> createCompletion(applicationCommand)
+                    "chat" -> chat(applicationCommand)
                     "image" -> createImage(applicationCommand)
                     "lodestone" -> lodestoneHandler(applicationCommand)
                     "rory" -> rory(applicationCommand)

--- a/sam/interact/src/main/kotlin/api/openai/chat/ChatRequest.kt
+++ b/sam/interact/src/main/kotlin/api/openai/chat/ChatRequest.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.Serializable
     val n: Byte = 1,
     val stream: Boolean = false,
     val stop: String? = null,
-    @SerialName("max_tokens") val maxTokens: Int = 2049,
+    @SerialName("max_tokens") val maxTokens: Short = 2000,
     @SerialName("presence_penalty") val presencePenalty: Double = 0.0,
     @SerialName("frequency_penalty") val frequencyPenalty: Double = 0.0,
 )

--- a/sam/interact/src/main/kotlin/api/openai/chat/Messages.kt
+++ b/sam/interact/src/main/kotlin/api/openai/chat/Messages.kt
@@ -1,0 +1,5 @@
+package cloud.drakon.tempestbot.interact.api.openai.chat
+
+import kotlinx.serialization.Serializable
+
+@Serializable class Messages(val messages: Array<Message>)

--- a/sam/interact/src/main/kotlin/commands/openai/Chat.kt
+++ b/sam/interact/src/main/kotlin/commands/openai/Chat.kt
@@ -8,7 +8,7 @@ import cloud.drakon.tempestbot.interact.api.openai.OpenAI
 import cloud.drakon.tempestbot.interact.api.openai.chat.ChatRequest
 import cloud.drakon.tempestbot.interact.api.openai.chat.Message
 
-suspend fun createCompletion(event: Interaction<ApplicationCommandData>) {
+suspend fun chat(event: Interaction<ApplicationCommandData>) {
     lateinit var message: String
 
     for (i in event.data !!.options !!) {

--- a/sam/interact/src/main/kotlin/commands/openai/Chat.kt
+++ b/sam/interact/src/main/kotlin/commands/openai/Chat.kt
@@ -43,8 +43,8 @@ suspend fun chat(event: Interaction<ApplicationCommandData>) {
         null
     }
 
-    val chatMessage: MutableList<Message> = messages?.messages?.toMutableList()
-        ?: mutableListOf()
+    val chatMessage: MutableList<Message> =
+        messages?.messages?.toMutableList() ?: mutableListOf()
     chatMessage.add(Message("user", message))
 
     Handler.ktDiscordClient.editOriginalInteractionResponse(

--- a/sam/interact/src/main/kotlin/commands/openai/Chat.kt
+++ b/sam/interact/src/main/kotlin/commands/openai/Chat.kt
@@ -7,37 +7,52 @@ import cloud.drakon.tempestbot.interact.Handler
 import cloud.drakon.tempestbot.interact.api.openai.OpenAI
 import cloud.drakon.tempestbot.interact.api.openai.chat.ChatRequest
 import cloud.drakon.tempestbot.interact.api.openai.chat.Message
+import cloud.drakon.tempestbot.interact.api.openai.chat.Messages
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Projections
 
 suspend fun chat(event: Interaction<ApplicationCommandData>) {
     lateinit var message: String
+    var assistant: String? = null
 
     for (i in event.data !!.options !!) {
         when (i.name) {
             "message" -> message = i.value !!
+            "assistant" -> assistant = i.value !!
         }
     }
 
-    val chatMessage =
-        if ("OPENAI_CHAT_ASSISTANT_MESSAGE" in System.getenv() && System.getenv("OPENAI_CHAT_ASSISTANT_MESSAGE")
-                .isNotEmpty()
-        ) {
-            arrayOf(
-                Message("system", System.getenv("OPENAI_CHAT_SYSTEM_MESSAGE")),
-                Message("assistant", System.getenv("OPENAI_CHAT_ASSISTANT_MESSAGE")),
-                Message("user", message)
-            )
-        } else {
-            arrayOf(
-                Message("system", System.getenv("OPENAI_CHAT_SYSTEM_MESSAGE")),
-                Message("user", message)
-            )
-        }
+    val defaultAssistant = System.getenv("CHAT_DEFAULT_ASSISTANT")
+    if (assistant == null && defaultAssistant.isNotEmpty()) {
+        assistant = defaultAssistant
+    }
 
+    val messages: Messages? = if (assistant != null) {
+        Handler.json.decodeFromString(
+            Messages.serializer(), Handler.mongoDatabase.getCollection("openai").find(
+                Filters.and(
+                    Filters.eq("command", "chat"), Filters.eq("assistant", assistant)
+                )
+            ).projection(
+                Projections.fields(
+                    Projections.include("messages"), Projections.excludeId()
+                )
+            ).first() !!.toJson()
+        )
+    } else {
+        null
+    }
+
+    val chatMessage: MutableList<Message> = messages?.messages?.toMutableList()
+        ?: mutableListOf()
+    chatMessage.add(Message("user", message))
 
     Handler.ktDiscordClient.editOriginalInteractionResponse(
         EditWebhookMessage(
             content = OpenAI(System.getenv("OPENAI_API_KEY")).createChatCompletion(
-                ChatRequest("gpt-3.5-turbo", chatMessage, temperature = 0.2)
+                ChatRequest(
+                    "gpt-3.5-turbo", chatMessage.toTypedArray(), temperature = 0.2
+                )
             ).choices[0].message.content
         ), event.token
     )

--- a/scripts/commands/commands.py
+++ b/scripts/commands/commands.py
@@ -5,6 +5,10 @@ import requests
 from localizations import languages, translate_text
 
 application_commands = json.load(open("commands.json", "r"))
+if len(os.environ["CHAT_ASSISTANTS"]) > 0:
+    for i in application_commands:
+        if i["name"] == "chat":
+            i["options"] = i["options"] + json.loads(os.environ["CHAT_ASSISTANTS"])
 
 application_id = os.environ["APPLICATION_ID"]
 bot_token = os.environ["BOT_TOKEN"]

--- a/template.yaml
+++ b/template.yaml
@@ -59,10 +59,8 @@ Resources:
             Ref: MongoDbDatabase
           OPENAI_API_KEY:
             Ref: OpenAiApiKey
-          OPENAI_CHAT_SYSTEM_MESSAGE:
-            Ref: OpenAiChatSystemMessage
-          OPENAI_CHAT_Assistant_MESSAGE:
-            Ref: OpenAiChatAssistantMessage
+          CHAT_DEFAULT_ASSISTANT:
+            Ref: ChatDefaultAssistant
       Policies:
         - Statement:
             - Sid: Translate
@@ -111,7 +109,6 @@ Parameters:
   OpenAiApiKey:
     Type: String
     NoEcho: True
-  OpenAiChatSystemMessage:
+  ChatDefaultAssistant:
     Type: String
-  OpenAiChatAssistantMessage:
-    Type: String
+    Default: ""


### PR DESCRIPTION
This allows the responses by the AI to be influenced according to the [OpenAI chat format](https://platform.openai.com/docs/guides/chat/introduction)